### PR TITLE
Add automated build and push workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Docker Hub
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '!v[0-9]+.[0-9]+.[0-9]+[ab][0-9]+'
+
+jobs:
+
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get version
+        id: vars
+        run: echo "version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ github.repository }}:latest,${{ github.repository }}:${{ steps.vars.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ Copy/paste this URL into a browser to view and run the example notebooks.
 ## Developer notes
 
 A versioned, multiplatform image built from this repository is hosted on Docker Hub
-at [mdpiper/bmi-example-python](https://hub.docker.com/r/mdpiper/bmi-example-python).
+at [csdms/bmi-example-python](https://hub.docker.com/r/csdms/bmi-example-python).
 To tag, build, and push an update, run:
 ```
-docker buildx build --platform linux/amd64,linux/arm64 -t mdpiper/bmi-example-python:<tagname> --push .
+docker buildx build --platform linux/amd64,linux/arm64 -t csdms/bmi-example-python:<tagname> --push .
 ```
 where `<tagname>` is, e.g., `0.3` or `latest`.
 
 A user can pull this image from Docker Hub with:
 ```
-docker pull mdpiper/bmi-example-python
+docker pull csdms/bmi-example-python
 ```

--- a/README.md
+++ b/README.md
@@ -51,13 +51,10 @@ Copy/paste this URL into a browser to view and run the example notebooks.
 ## Developer notes
 
 A versioned, multiplatform image built from this repository is hosted on Docker Hub
-at [csdms/bmi-example-python](https://hub.docker.com/r/csdms/bmi-example-python).
-To tag, build, and push an update, run:
-```
-docker buildx build --platform linux/amd64,linux/arm64 -t csdms/bmi-example-python:<tagname> --push .
-```
-where `<tagname>` is, e.g., `0.3` or `latest`.
-
+at [csdms/bmi-example-python](https://hub.docker.com/repository/docker/csdms/bmi-example-python-docker/).
+This image is automatically built and pushed to Docker Hub
+with the [release](./.github/workflows/release.yml) CI workflow.
+The workflow is only run when the repository is tagged.
 A user can pull this image from Docker Hub with:
 ```
 docker pull csdms/bmi-example-python


### PR DESCRIPTION
Docker has developed a series of actions that allow an image to be built and pushed to Docker Hub. In this PR, I set up a workflow that, on a tagged release, builds the *bmi-example-python-docker* image on two platforms (linux/amd64 and linux/arm64) and pushes them to the CSDMS organization on Docker Hub. All I have to do is tag the repo and push the tag; the workflow takes care of the rest. The workflow is only run on `git push --tags`.